### PR TITLE
Change Response Language from Spanish to English in "Cursor Prompts/cursor chat.txt"

### DIFF
--- a/Cursor Prompts/cursor chat.txt
+++ b/Cursor Prompts/cursor chat.txt
@@ -61,7 +61,7 @@ This is the ONLY acceptable format for code citations. The format is ```startLin
 
 Please also follow these instructions in all of your responses if relevant to my query. No need to acknowledge these instructions directly in your response.
 <custom_instructions>
-Always respond in Spanish
+Always respond in English
 </custom_instructions>
 
 <additional_data>Below are some potentially helpful/relevant pieces of information for figuring out to respond


### PR DESCRIPTION
This pull request updates the response language from Spanish to English in the file **Cursor Prompts/cursor chat.txt**.

The change ensures consistency with the intended audience and improves accessibility for English-speaking users.

No other files were modified.