### PR TITLE
Included links to individual folders and added missing links

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,28 +58,32 @@ You can show your support via:
 
 ## 📂 Available Files
 
-- **v0 Folder**
-- **Spawn Folder**  
-- **Manus Folder**  
-- **Lovable Folder**  
-- **Devin Folder**  
-- **Same.dev Folder**  
-- **Replit Folder**  
-- **Windsurf Agent Folder**  
-- **VSCode (Copilot) Agent Folder**  
-- **Cursor Folder**  
-- **Dia Folder**  
-- **Trae AI Folder**
-- **Perplexity Folder**  
-- **Cluely Folder**
-- **Xcode Folder**
-- **Orchids.app Folder**
-- **Open Source prompts Folder**  
-  - Codex CLI  
-  - Cline  
-  - Bolt  
-  - RooCode
-  - Lumo
+- [**v0 Folder**](./v0%20Prompts%20and%20Tools/)
+- [**Spawn Folder**](./-Spawn/)
+- [**Manus Folder**](./Manus%20Agent%20Tools%20&%20Prompt/)
+- [**Lovable Folder**](./Lovable/)
+- [**Devin Folder**](./Devin%20AI/)
+- [**Same.dev Folder**](./Same.dev/)
+- [**Replit Folder**](./Replit/)
+- [**Windsurf Agent Folder**](./Windsurf/)
+- [**VSCode (Copilot) Agent Folder**](./VSCode%20Agent/)
+- [**Cursor Folder**](./Cursor%20Prompts/)
+- [**Dia Folder**](./dia/)
+- [**Trae AI Folder**](./Trae/)
+- [**Perplexity Folder**](./Perplexity/)
+- [**Cluely Folder**](./Cluely/)
+- [**Xcode Folder**](./Xcode/)
+- [**Orchids.app Folder**](./Orchids.app/)
+- [**Junie Folder**](./Junie/)
+- [**Kiro**](./Kiro/)
+- [**Wrap.dev**](./Warp.dev/)
+- [**Z.ai Code**](./Z.ai%20Code/)
+- [**Open Source prompts Folder**](./Open%20Source%20prompts/)
+  - [Codex CLI](./Open%20Source%20prompts/Codex%20CLI/)
+  - [Cline](./Open%20Source%20prompts/Cline/)
+  - [Bolt](./Open%20Source%20prompts/Bolt/)
+  - [RooCode](./Open%20Source%20prompts/RooCode/)
+  - [Lumo](./Open%20Source%20prompts/Lumo/)
 
 ---
 


### PR DESCRIPTION
The Readme file now contains links to folders containing prompts.
The following folders did not have links in the readme, and have now been added
 - Junie folder
 - Kiro folder
 - Wrap.dev folder
 - Z.ai folder