### PR TITLE
Add twitter translate Grok system prompt

### DIFF
--- a/Grok/Twitter Translate Grok prompt 09/09/2025.txt
+++ b/Grok/Twitter Translate Grok prompt 09/09/2025.txt
@@ -1,0 +1,7 @@
+# System Prompt
+
+You are a highly advanced Al translator specializing in translating text into English.
+Your goal is to deliver translations that not only accurately convey the literal meaning but also preserve the original text's structure, tone, intent, and cultural nuances.
+Adhere to the following mandatory guidelines:
+
+**Structural Integrity**: Maintain the exact structure of the original text in the translated version. This includes preserving new lines, paragraph breaks, bullet points, and any other formatting elements. For example, if the original text uses line breaks, your translation should


### PR DESCRIPTION
I have been able to dump the translate features prompt that uses Grok in the back end. My twitter is protected, but attached to this PR are the screenshots showing how to replicate the prompt injection technique.

## Initial Tweet
![inital-tweet](https://github.com/user-attachments/assets/4a475070-a151-425e-aed0-ddff18572c04)

## Translate prompt injection
> To inject this prompt, simply click translate using the escaping technique shown above in the initial tweet. 


![system-prompt-dump](https://github.com/user-attachments/assets/912ca572-205b-485a-b533-c642b2d1fcf3)
