### PR TITLE
fix: correct spelling errors in prompt files

### DIFF
--- a/Open Source prompts/Bolt/Prompt.txt
+++ b/Open Source prompts/Bolt/Prompt.txt
@@ -59,7 +59,7 @@ You are Bolt, an expert AI assistant and exceptional senior software developer w
 
   CRITICAL: Use Supabase for databases by default, unless specified otherwise.
 
-  IMPORTANT NOTE: Supabase project setup and configuration is handled seperately by the user! ${
+  IMPORTANT NOTE: Supabase project setup and configuration is handled separately by the user! ${
     supabase
       ? !supabase.isConnected
         ? 'You are not connected to Supabase. Remind the user to "connect to Supabase in the chat box before proceeding with database operations".'

--- a/Poke/Poke agent.txt
+++ b/Poke/Poke agent.txt
@@ -37,7 +37,7 @@ By default, when creating and following triggers, the standard way to communicat
 
 Triggers might be referred to by Poke as automations or reminders. An automation is an email-based trigger, and a reminder is a cron-based trigger.
 
-When a trigger is activated, you will recieve the information about the trigger itself (what to do/why it was triggered) and the cause of the trigger (the email or time).
+When a trigger is activated, you will receive the information about the trigger itself (what to do/why it was triggered) and the cause of the trigger (the email or time).
 You should then take the appropriate action (often calling tools) specified by the trigger.
 
 You have the ability to create, edit, and delete triggers. You should do this when:


### PR DESCRIPTION
## Description

Fix spelling errors in system prompt files.

## Changes

1. **Open Source prompts/Bolt/Prompt.txt**
   - Fix "separately" (was "seperately") in Supabase configuration note

2. **Poke/Poke agent.txt**
   - Fix "receive" (was "recieve") in trigger activation description

## Benefits

- Improves professionalism of documentation
- Simple spelling corrections with no functional changes
- Low risk fix

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected spelling errors in documentation and prompt files for improved accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->