### PR TITLE
Add CLAUDE.md with Antigravity Swarm project context

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,7 +14,7 @@
 GitHub Actions (CI trigger)
         │
         ▼
-   worker.py          ← agent ראשי שמושך משימות ומבצע
+   Worker agent entrypoint   ← הסקריפט הראשי שמושך משימות ומבצע
         │
         ├── שולף מ-task_queue (Supabase)
         ├── כותב תוצאות ל-agent_memory (Supabase)
@@ -25,7 +25,7 @@ GitHub Actions (CI trigger)
 
 | רכיב | תפקיד |
 |------|--------|
-| `worker.py` | Agent ראשי — שולף משימות מה-queue ומבצע |
+| Worker agent (entrypoint) | Agent ראשי — שולף משימות מה-queue ומבצע (שם הקובץ בפועל תלוי במימוש/רפו, למשל `main.py` או סקריפט אחר) |
 | `GitHub Actions` | Trigger לריצת workers (scheduled / event-driven) |
 | `Supabase` | Backend מרכזי — DB + Auth + Realtime |
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,69 @@
+# Antigravity Swarm — Project Context
+
+## תיאור הפרויקט
+
+**Antigravity Swarm** הוא מערכת multi-agent אוטונומית המבוססת על תזמון משימות מרכזי דרך Supabase, עם agents שפועלים כ-workers על GitHub Actions ו-locally.
+
+המטרה: ביצוע משימות AI מקבילי ועצמאי, עם זיכרון משותף ותיאום בין agents.
+
+---
+
+## ארכיטקטורה
+
+```
+GitHub Actions (CI trigger)
+        │
+        ▼
+   worker.py          ← agent ראשי שמושך משימות ומבצע
+        │
+        ├── שולף מ-task_queue (Supabase)
+        ├── כותב תוצאות ל-agent_memory (Supabase)
+        └── מעדכן claude_context לפני כל סשן
+```
+
+### רכיבים
+
+| רכיב | תפקיד |
+|------|--------|
+| `worker.py` | Agent ראשי — שולף משימות מה-queue ומבצע |
+| `GitHub Actions` | Trigger לריצת workers (scheduled / event-driven) |
+| `Supabase` | Backend מרכזי — DB + Auth + Realtime |
+
+---
+
+## טבלאות Supabase
+
+### `task_queue`
+תור המשימות המרכזי של ה-Swarm.
+
+| עמודה | סוג | תיאור |
+|-------|-----|--------|
+| `id` | uuid | מזהה ייחודי |
+| `task_type` | text | סוג המשימה |
+| `payload` | jsonb | נתוני הקלט |
+| `status` | text | `pending / in_progress / done / failed` |
+| `assigned_to` | text | שם ה-agent שקיבל |
+| `created_at` | timestamp | זמן יצירה |
+| `updated_at` | timestamp | עדכון אחרון |
+
+### `agent_memory`
+זיכרון משותף בין כל ה-agents.
+
+| עמודה | סוג | תיאור |
+|-------|-----|--------|
+| `id` | uuid | מזהה ייחודי |
+| `agent_id` | text | שם/מזהה ה-agent |
+| `key` | text | מפתח הזיכרון |
+| `value` | jsonb | תוכן הזיכרון |
+| `context_type` | text | `task / learning / state` |
+| `created_at` | timestamp | זמן שמירה |
+
+---
+
+## חוקי עבודה
+
+1. **תמיד commit אחרי שינוי** — כל שינוי קוד מלווה ב-commit עם הודעה ברורה
+2. **תמיד עדכן `claude_context`** — לפני סיום כל סשן, עדכן את ה-context ב-`agent_memory` עם מה שנעשה
+3. **אל תשנה `task_queue` ידנית** — רק דרך `worker.py` או API מוגדר
+4. **status transitions** — `pending → in_progress → done/failed` בלבד, לעולם לא אחורה
+5. **secrets** — API keys רק דרך GitHub Secrets (CI) או `~/.antigravity.env` (local)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,6 +60,33 @@ GitHub Actions (CI trigger)
 
 ---
 
+## תקשורת ישירה עם Antigravity (ללא מתווך)
+
+Supabase project: `ayhplxbihuyimtrzimrh` (Antigravity-Brain, eu-central-1)
+
+**בתחילת כל סשן — בדוק inbox:**
+```sql
+SELECT id, from_agent, subject, message, priority, created_at
+FROM claude_inbox WHERE status = 'unread' ORDER BY priority DESC, created_at ASC;
+```
+אם יש הודעות — קרא, סמן כ-read, והגב ל-`claude_outbox`.
+
+**לכתוב תשובה ל-Antigravity:**
+```sql
+INSERT INTO claude_outbox (to_agent, subject, message, message_type)
+VALUES ('antigravity', '<subject>', '<message>', 'response');
+```
+
+**ערוצי תקשורת:**
+| טבלה | כיוון | תיאור |
+|------|--------|--------|
+| `claude_inbox` | Antigravity → Claude | הודעות נכנסות |
+| `claude_outbox` | Claude → Antigravity | תשובות ויוזמות |
+| `hive_comms` | דו-כיווני | broadcast כללי |
+| `task_queue` | משותף | משימות לביצוע |
+
+---
+
 ## חוקי עבודה
 
 1. **תמיד commit אחרי שינוי** — כל שינוי קוד מלווה ב-commit עם הודעה ברורה


### PR DESCRIPTION
## Summary

- Add `CLAUDE.md` documenting the Antigravity Swarm multi-agent architecture
- Documents Supabase schema (`task_queue`, `agent_memory`) and working rules
- Adds direct Claude↔Antigravity communication protocol via Supabase channels (`claude_inbox`, `claude_outbox`, `hive_comms`) — no human middleman required

## Test plan

- [x] Verify `CLAUDE.md` renders correctly on GitHub
- [x] Confirm Supabase channel references are accurate

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive project documentation describing overall architecture, component roles, communication patterns, data flows, and governance.
  * Includes operational guidelines for task handling, state transitions, context updates, security practices, and example interaction patterns.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->