### PR TITLE
docs: add gitcgr code graph badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,9 @@
 <a href="https://discord.gg/NwzrWErdMU" target="_blank">
   <img src="https://img.shields.io/discord/1402660735833604126?label=LeaksLab%20Discord&logo=discord&style=for-the-badge" alt="LeaksLab Discord" />
 </a>
+  <a href="https://gitcgr.com/x1xhlol/system-prompts-and-models-of-ai-tools" target="_blank" rel="noopener noreferrer">
+    <img src="https://gitcgr.com/badge/x1xhlol/system-prompts-and-models-of-ai-tools.svg" alt="gitcgr" />
+  </a>
 
 
 <a href="https://trendshift.io/repositories/14084" target="_blank"><img src="https://trendshift.io/api/badge/repositories/14084" alt="x1xhlol%2Fsystem-prompts-and-models-of-ai-tools | Trendshift" style="width: 250px; height: 55px;" width="250" height="55"/></a>


### PR DESCRIPTION
Someone visualized your repository on [gitcgr.com](https://gitcgr.com/x1xhlol/system-prompts-and-models-of-ai-tools)! This badge lets visitors explore your codebase as an interactive graph.

**Badge preview:**

[![gitcgr](https://gitcgr.com/badge/x1xhlol/system-prompts-and-models-of-ai-tools.svg)](https://gitcgr.com/x1xhlol/system-prompts-and-models-of-ai-tools)

Clicking the badge takes users to an interactive visualization of your code structure — functions, classes, modules, and their relationships.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded the README with a new external reference link badge. The badge appears alongside the existing repository badges and provides users with convenient quick access to an additional external resource. The implementation utilizes an SVG image element paired with a hyperlink, enhancing overall repository navigation and resource discoverability for end-users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->