### PR TITLE
Update Latitude links to new landing page

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,15 +3,15 @@
 </p>
 
 <p align="center">
-  <a href="https://github.com/latitude-dev/latitude-llm">
+  <a href="https://latitude.so/?utm_source=github&utm_medium=readme&utm_campaign=sponsorship">
     <img src="assets/latitude-dark.png" alt="Latitude Logo" width="700"/>
   </a>
 </p>
 
 <div align="center" markdown="1">
 
-### [Issue Tracking for AI Agents](https://github.com/latitude-dev/latitude-llm)  
-[Open Source Monitoring platform](https://github.com/latitude-dev/latitude-llm)
+### [Issue Tracking for AI Agents](https://latitude.so/?utm_source=github&utm_medium=readme&utm_campaign=sponsorship)  
+[Open Source Monitoring platform](https://latitude.so/?utm_source=github&utm_medium=readme&utm_campaign=sponsorship)
 
 </div>
 


### PR DESCRIPTION
## Summary
- Points the three Latitude links in the README to the new landing page at https://latitude.so/
- Adds UTM parameters (source=github, medium=readme, campaign=sponsorship) for attribution

## Test plan
- [ ] Links resolve to the new landing page
- [ ] UTMs show up correctly in analytics

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated project attribution and reference links to point to the Latitude.so sponsorship and issue-tracking pages instead of the GitHub repository.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->