### PR TITLE
docs: add contribution guidance and PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,23 @@
+## Summary
+
+<!-- Briefly describe what this PR adds or changes. -->
+
+## Source / Provenance
+
+- Product:
+- Source link or related issue:
+- Capture date:
+- Model/version/UI surface, if known:
+- Redactions or formatting changes:
+
+## Validation
+
+- [ ] Searched existing issues and PRs for duplicates
+- [ ] Removed sensitive or personal data
+- [ ] Preserved original prompt wording where possible
+- [ ] Ran `git diff --check`
+- [ ] Ran JSON validation for changed `.json` files, if applicable
+
+## Notes
+
+<!-- Add reviewer context, follow-ups, or limitations here. -->

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,64 @@
+# Contributing
+
+Thanks for helping improve this collection of AI system prompts, model notes, and tool definitions. Contributions are easiest to review when they are small, sourced, and careful with privacy.
+
+## What To Contribute
+
+- New prompt or tool dumps for AI products that are not already covered.
+- Updates to existing prompts when the product, model, or tool surface has changed.
+- Formatting fixes that make prompt files easier to read without changing meaning.
+- Validity fixes for structured files, especially JSON tool definitions.
+- Source notes, dates, or reproduction details that make an existing entry easier to verify.
+
+## Before Opening A PR
+
+1. Search existing issues and pull requests for the product or file you want to update.
+2. Keep each PR focused on one product, prompt set, or cleanup task.
+3. Preserve original prompt wording as much as possible. Put extra context in a README or note file instead of mixing commentary into the prompt.
+4. Remove personal information, access tokens, account IDs, private workspace names, and other sensitive data.
+5. Do not submit copyrighted product documentation or user content unless it is necessary provenance and you have the right to share it.
+
+## Suggested Folder Layout
+
+For a new product, prefer a dedicated top-level folder named after the product or vendor:
+
+```text
+Product Name/
+  Prompt.txt
+  Tools.json
+  README.md
+```
+
+Use the filenames that best match the existing nearby entries. If only one artifact is available, include only that file.
+
+## Provenance
+
+When possible, include a short `README.md` or note with:
+
+- Product name and URL.
+- Capture date.
+- Product version, model name, or UI surface, if known.
+- How the prompt or tools were obtained.
+- Any redactions or formatting changes you made.
+
+If provenance is already clear from an issue, link that issue in the PR description.
+
+## Validation
+
+Run the checks that match the files you changed:
+
+```bash
+python -m json.tool "Product Name/Tools.json"
+git diff --check
+```
+
+For Markdown-only changes, `git diff --check` is usually enough. Mention any checks that were not applicable in the PR description.
+
+## Pull Request Checklist
+
+- [ ] I searched for duplicate issues and pull requests.
+- [ ] The PR is focused and does not mix unrelated products or cleanups.
+- [ ] Prompts preserve the original wording where possible.
+- [ ] Sensitive or personal data has been removed.
+- [ ] Sources, capture date, and redactions are documented when available.
+- [ ] JSON files parse successfully, if this PR changes JSON.


### PR DESCRIPTION
## Summary

Adds lightweight contribution guidance for the repository without changing any prompt content:

- Adds `CONTRIBUTING.md` with guidance for scoped PRs, provenance, privacy redaction, folder layout, and validation.
- Adds `.github/PULL_REQUEST_TEMPLATE.md` to encourage consistent source/provenance and validation notes in future submissions.

## Why

The repository receives many prompt submissions and cleanup PRs. A focused contributor guide and PR template should make future contributions easier to review while keeping this change small and documentation-only.

## Validation

- `git diff --cached --check` before commit
- No JSON validation needed; Markdown-only change

## Notes

This avoids README changes so it does not conflict with broader README contribution-guide proposals.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added pull request template with structured sections for summaries, source information, validation, and notes.
  * Added contributor guidelines covering submission scope, privacy requirements, folder conventions, and validation procedures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->