### PR TITLE
Update Latitude links to point to GitHub repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,15 +3,15 @@
 </p>
 
 <p align="center">
-  <a href="https://latitude.so/?utm_source=github&utm_medium=readme&utm_campaign=sponsorship">
+  <a href="https://github.com/latitude-dev/latitude-llm">
     <img src="assets/latitude-dark.png" alt="Latitude Logo" width="700"/>
   </a>
 </p>
 
 <div align="center" markdown="1">
 
-### [Issue Tracking for AI Agents](https://latitude.so/?utm_source=github&utm_medium=readme&utm_campaign=sponsorship)  
-[Open Source Monitoring platform](https://latitude.so/?utm_source=github&utm_medium=readme&utm_campaign=sponsorship)
+### [Issue Tracking for AI Agents](https://github.com/latitude-dev/latitude-llm)  
+[Open Source Monitoring platform](https://github.com/latitude-dev/latitude-llm)
 
 </div>
 


### PR DESCRIPTION
## Summary
- Point the Latitude sponsorship links in the README to the [latitude-dev/latitude-llm](https://github.com/latitude-dev/latitude-llm) repo instead of the marketing site.

## Test plan
- [x] Verified README links render and resolve to the GitHub repo

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated issue tracking and resource links in project documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->